### PR TITLE
Add Checkov security scanning workflow

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -1,0 +1,29 @@
+name: Checkov Security Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  checkov:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Checkov
+        uses: bridgecrewio/checkov-action@v12
+        with:
+          directory: .
+          output_format: sarif
+          output_file_path: results.sarif
+          soft_fail: true
+
+      - name: Upload SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/aws/vulnerable-s3/main.tf
+++ b/aws/vulnerable-s3/main.tf
@@ -1,0 +1,39 @@
+# INTENTIONALLY VULNERABLE - FOR TESTING CHECKOV SECURITY SCAN
+# This file contains multiple security issues that checkov should detect
+
+resource "aws_s3_bucket" "vulnerable_bucket" {
+  bucket = "my-vulnerable-test-bucket"
+
+  # Missing: server-side encryption
+  # Missing: versioning
+  # Missing: logging
+  # Missing: public access block
+}
+
+# Intentionally allowing public access
+resource "aws_s3_bucket_public_access_block" "vulnerable_bucket" {
+  bucket = aws_s3_bucket.vulnerable_bucket.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+# Insecure bucket policy allowing public read
+resource "aws_s3_bucket_policy" "vulnerable_policy" {
+  bucket = aws_s3_bucket.vulnerable_bucket.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "PublicReadGetObject"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "s3:GetObject"
+        Resource  = "${aws_s3_bucket.vulnerable_bucket.arn}/*"
+      }
+    ]
+  })
+}


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for automated Checkov security scanning on PRs and pushes to main
- Include intentionally vulnerable S3 bucket terraform config to test the security scan

## What this PR does
1. **Checkov Workflow** (`.github/workflows/checkov.yml`): Runs on every push to main and PR targeting main, outputs SARIF format and uploads to GitHub Security tab

2. **Test Vulnerability** (`aws/vulnerable-s3/main.tf`): Intentionally insecure S3 bucket with:
   - No server-side encryption
   - No versioning
   - Public access allowed
   - Overly permissive bucket policy

## Expected Results
The checkov scan should detect multiple security issues and report them in this PR's checks and the repository Security tab after merge.

## Test plan
- [ ] Verify checkov workflow runs on this PR
- [ ] Confirm security findings appear in PR checks
- [ ] After merge, verify findings appear in Security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)