### PR TITLE
test(COD-7244): verify codesec.yaml suppression keeps findings out of PR feedback

### DIFF
--- a/.lacework/codesec.yaml
+++ b/.lacework/codesec.yaml
@@ -1,0 +1,8 @@
+default:
+  iac:
+    enabled: true
+    pullRequest:
+      statusCheck: any
+      statusComments: all
+    scan:
+      terraform: true

--- a/.lacework/codesec.yaml
+++ b/.lacework/codesec.yaml
@@ -6,3 +6,5 @@ default:
       statusComments: all
     scan:
       terraform: true
+      exceptions:
+        - "path:suppression-test/*:Accepted risk"

--- a/suppression-test/main.tf
+++ b/suppression-test/main.tf
@@ -1,25 +1,39 @@
-// Fixture for COD-7244. Intentionally insecure, never deployed.
-// Used to verify that a codesec.yaml path exception keeps these findings out of
-// PR comments and the status check while leaving them visible in the console.
+// COD-7244 suppression fixture. Intentionally insecure, never deployed.
+// Uses an inline ingress block so the wide-open-ingress policy fires, and
+// deliberately distinctive resource names and surrounding text so the partial
+// fingerprint cannot collide with an existing finding on the default branch.
 
-resource "aws_security_group_rule" "open_ingress" {
-  type        = "ingress"
-  from_port   = 0
-  to_port     = 0
-  protocol    = "-1"
-  cidr_blocks = ["0.0.0.0/0"]
+resource "aws_security_group" "cod7244_wide_open_ingress_fixture" {
+  name        = "cod7244-wide-open-ingress-fixture"
+  description = "COD-7244 fixture group, exposes every tcp port to the whole internet"
+
+  ingress {
+    description = "cod7244 fixture, all tcp from anywhere"
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "cod7244 fixture, unrestricted egress"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 }
 
-resource "aws_alb_listener" "plaintext_http" {
-  port     = "80"
-  protocol = "HTTP"
+resource "aws_s3_bucket" "cod7244_public_unencrypted_fixture" {
+  bucket = "cod7244-public-unencrypted-fixture"
+  acl    = "public-read-write"
 }
 
-resource "aws_s3_bucket" "unencrypted" {
-  bucket = "cod-7244-suppression-fixture"
-  acl    = "public-read"
-}
-
-resource "aws_api_gateway_domain_name" "outdated_tls" {
-  security_policy = "TLS_1_0"
+resource "aws_db_instance" "cod7244_unencrypted_db_fixture" {
+  identifier          = "cod7244-unencrypted-db-fixture"
+  engine              = "mysql"
+  instance_class      = "db.t3.micro"
+  storage_encrypted   = false
+  publicly_accessible = true
+  skip_final_snapshot = true
 }

--- a/suppression-test/main.tf
+++ b/suppression-test/main.tf
@@ -1,0 +1,25 @@
+// Fixture for COD-7244. Intentionally insecure, never deployed.
+// Used to verify that a codesec.yaml path exception keeps these findings out of
+// PR comments and the status check while leaving them visible in the console.
+
+resource "aws_security_group_rule" "open_ingress" {
+  type        = "ingress"
+  from_port   = 0
+  to_port     = 0
+  protocol    = "-1"
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
+resource "aws_alb_listener" "plaintext_http" {
+  port     = "80"
+  protocol = "HTTP"
+}
+
+resource "aws_s3_bucket" "unencrypted" {
+  bucket = "cod-7244-suppression-fixture"
+  acl    = "public-read"
+}
+
+resource "aws_api_gateway_domain_name" "outdated_tls" {
+  security_policy = "TLS_1_0"
+}


### PR DESCRIPTION
Test fixture for COD-7244, validating the git-bridge fix deployed to DEV5.

**Step 1 (this commit):** adds `suppression-test/main.tf` with intentionally insecure Terraform, with no exception configured. Expected: Lacework (IAC) reports these as new findings and the status check fails.

**Step 2 (next commit):** adds a `.lacework/codesec.yaml` path exception covering that folder. Expected: the same findings stop appearing in PR feedback and the status check passes, while remaining visible in the console under Suppressed.

Not for merge.