### PR TITLE
test(COD-7036): mixed-case SCA severity coercion

### DIFF
--- a/.lacework/codesec.yaml
+++ b/.lacework/codesec.yaml
@@ -1,0 +1,11 @@
+# COD-7036 test fixture. Intentionally mixed-case SCA severity values.
+# Before the fix, the strict schema enum rejects "Critical"/"High" and the
+# whole scan profile is dropped. After the fix, the read path coerces them to
+# lowercase and the severity filter is applied correctly.
+default:
+  sca:
+    enabled: true
+    scan:
+      severity:
+        - Critical
+        - High


### PR DESCRIPTION
Test PR for COD-7036. Adds `.lacework/codesec.yaml` with non-canonical (mixed-case) `sca.scan.severity` values (`Critical`, `High`).

Purpose: verify on DEV5 that the codesec severity read path coerces mixed-case values to lowercase and applies the filter, instead of rejecting the whole scan profile on the strict enum.

Expected with the fix deployed: the config is accepted, severities are treated as `critical`/`high`, and SCA findings are filtered to those severities (not silently zero).